### PR TITLE
adds error catching to handle method

### DIFF
--- a/src/JobPipeline.php
+++ b/src/JobPipeline.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Stancl\JobPipeline;
 
 use Closure;
-use Throwable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class JobPipeline implements ShouldQueue
 {
@@ -66,9 +67,8 @@ class JobPipeline implements ShouldQueue
 
             try {
                 $result = app()->call($job);
-            } catch(Throwable $exception) {
-                if ( method_exists(get_class($job[0]), 'failed') ) {
-                    
+            } catch (Throwable $exception) {
+                if (method_exists(get_class($job[0]), 'failed')) {
                     call_user_func_array([$job[0], 'failed'], [$exception]);
                 } else {
                     Log::error($exception);

--- a/src/JobPipeline.php
+++ b/src/JobPipeline.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stancl\JobPipeline;
 
 use Closure;
+use Throwable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 class JobPipeline implements ShouldQueue
@@ -63,7 +64,18 @@ class JobPipeline implements ShouldQueue
                 $job = [new $job(...$this->passable), 'handle'];
             }
 
-            $result = app()->call($job);
+            try {
+                $result = app()->call($job);
+            } catch(Throwable $exception) {
+                if ( method_exists(get_class($job[0]), 'failed') ) {
+                    
+                    call_user_func_array([$job[0], 'failed'], [$exception]);
+                } else {
+                    Log::error($exception);
+                }
+
+                break;
+            }
 
             if ($result === false) {
                 break;


### PR DESCRIPTION
This PR proposes a fix that should allow the pipeline to appropriately call the `failed()` method of the job.  See description of issue in #8.