### PR TITLE
fix: handle errors in closures [1.x]

### DIFF
--- a/src/JobPipeline.php
+++ b/src/JobPipeline.php
@@ -61,9 +61,7 @@ class JobPipeline implements ShouldQueue
     {
         foreach ($this->jobs as $job) {
             if (is_string($job)) {
-                if (!str_contains($job, '@')) {
-                    $job = [new $job(...$this->passable), 'handle'];
-                }
+                $job = [new $job(...$this->passable), 'handle'];
             }
 
             try {

--- a/src/JobPipeline.php
+++ b/src/JobPipeline.php
@@ -67,7 +67,7 @@ class JobPipeline implements ShouldQueue
             }
 
             try {
-                $result = app()->call($job, $this->passable);
+                $result = app()->call($job);
             } catch (Throwable $exception) {
                 if (is_array($job) && method_exists(get_class($job[0]), 'failed')) {
                     call_user_func_array([$job[0], 'failed'], [$exception]);

--- a/src/JobPipeline.php
+++ b/src/JobPipeline.php
@@ -61,13 +61,15 @@ class JobPipeline implements ShouldQueue
     {
         foreach ($this->jobs as $job) {
             if (is_string($job)) {
-                $job = [new $job(...$this->passable), 'handle'];
+                if (!str_contains($job, '@')) {
+                    $job = [new $job(...$this->passable), 'handle'];
+                }
             }
 
             try {
                 $result = app()->call($job, $this->passable);
             } catch (Throwable $exception) {
-                if (method_exists(get_class($job[0]), 'failed')) {
+                if (is_array($job) && method_exists(get_class($job[0]), 'failed')) {
                     call_user_func_array([$job[0], 'failed'], [$exception]);
                 } else {
                     throw $exception;

--- a/src/JobPipeline.php
+++ b/src/JobPipeline.php
@@ -65,7 +65,7 @@ class JobPipeline implements ShouldQueue
             }
 
             try {
-                $result = app()->call($job);
+                $result = app()->call($job, $this->passable);
             } catch (Throwable $exception) {
                 if (method_exists(get_class($job[0]), 'failed')) {
                     call_user_func_array([$job[0], 'failed'], [$exception]);

--- a/tests/JobPipelineTest.php
+++ b/tests/JobPipelineTest.php
@@ -167,6 +167,40 @@ class JobPipelineTest extends TestCase
 
         $this->assertTrue($passes);
     }
+
+    /** @test */
+    public function send_can_pass_parameters_to_method()
+    {
+        Event::listen(TestEvent::class, JobPipeline::make([
+            [new FooJobWithMethod(), 'foo']
+        ])->send(function () {
+            return $this->valuestore;
+        })->toListener());
+
+        $this->assertFalse($this->valuestore->has('foo'));
+
+        event(new TestEvent(new TestModel()));
+
+        $this->assertSame('bar', $this->valuestore->get('foo'));
+    }
+
+    /** @test */
+    public function send_can_pass_parameters_to_method_with_at_syntax()
+    {
+        app()->bind('FooJobWithMethod', fn () => new FooJobWithMethod());
+
+        Event::listen(TestEvent::class, JobPipeline::make([
+            'FooJobWithMethod@foo'
+        ])->send(function () {
+            return $this->valuestore;
+        })->toListener());
+
+        $this->assertFalse($this->valuestore->has('foo'));
+
+        event(new TestEvent(new TestModel()));
+
+        $this->assertSame('bar', $this->valuestore->get('foo'));
+    }
 }
 
 class FooJob
@@ -285,5 +319,16 @@ class ExceptionJob
     public function failed(\Throwable $e)
     {
         $this->valuestore->put('exeception', $e->getMessage());
+    }
+}
+
+class FooJobWithMethod
+{
+    // variadic arguments must be used so the container doesn't try to inject any value
+    public function foo(...$arguments)
+    {
+        [$valuestore] = $arguments;
+
+        $valuestore->put('foo', 'bar');
     }
 }

--- a/tests/JobPipelineTest.php
+++ b/tests/JobPipelineTest.php
@@ -162,7 +162,7 @@ class JobPipelineTest extends TestCase
             }
         ])->send(function (TestEvent $event) {
             return $event->testModel;
-        })->toListener());
+        })->shouldBeQueued(false)->toListener());
 
         event(new TestEvent(new TestModel()));
 
@@ -172,25 +172,17 @@ class JobPipelineTest extends TestCase
     /** @test */
     public function failures_in_closures_will_throw_correctly()
     {
-        $passes = true;
+        $this->expectExceptionMessage('foobar');
 
         Event::listen(TestEvent::class, JobPipeline::make([
-            function () use (&$passes) {
-                try {
-                    throw new Exception('foobar');
-                } catch (Exception) {
-                    $passes = false;
-                }
+            function () {
+                throw new Exception('foobar');
             }
         ])->send(function (TestEvent $event) {
             return $this->valuestore;
         })->toListener());
 
         event(new TestEvent(new TestModel()));
-
-        sleep(1);
-
-        $this->assertFalse($passes);
     }
 }
 

--- a/tests/JobPipelineTest.php
+++ b/tests/JobPipelineTest.php
@@ -162,7 +162,7 @@ class JobPipelineTest extends TestCase
             }
         ])->send(function (TestEvent $event) {
             return $event->testModel;
-        })->shouldBeQueued(false)->toListener());
+        })->toListener());
 
         event(new TestEvent(new TestModel()));
 
@@ -180,7 +180,7 @@ class JobPipelineTest extends TestCase
             }
         ])->send(function (TestEvent $event) {
             return $this->valuestore;
-        })->toListener());
+        })->shouldBeQueued(false)->toListener());
 
         event(new TestEvent(new TestModel()));
     }

--- a/tests/JobPipelineTest.php
+++ b/tests/JobPipelineTest.php
@@ -2,6 +2,7 @@
 
 namespace Stancl\JobPipeline\Tests;
 
+use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
@@ -169,37 +170,27 @@ class JobPipelineTest extends TestCase
     }
 
     /** @test */
-    public function send_can_pass_parameters_to_method()
+    public function failures_in_closures_will_throw_correctly()
     {
+        $passes = true;
+
         Event::listen(TestEvent::class, JobPipeline::make([
-            [new FooJobWithMethod(), 'foo']
-        ])->send(function () {
+            function () use (&$passes) {
+                try {
+                    throw new Exception('foobar');
+                } catch (Exception) {
+                    $passes = false;
+                }
+            }
+        ])->send(function (TestEvent $event) {
             return $this->valuestore;
         })->toListener());
 
-        $this->assertFalse($this->valuestore->has('foo'));
-
         event(new TestEvent(new TestModel()));
 
-        $this->assertSame('bar', $this->valuestore->get('foo'));
-    }
+        sleep(1);
 
-    /** @test */
-    public function send_can_pass_parameters_to_method_with_at_syntax()
-    {
-        app()->bind('FooJobWithMethod', fn () => new FooJobWithMethod());
-
-        Event::listen(TestEvent::class, JobPipeline::make([
-            'FooJobWithMethod@foo'
-        ])->send(function () {
-            return $this->valuestore;
-        })->toListener());
-
-        $this->assertFalse($this->valuestore->has('foo'));
-
-        event(new TestEvent(new TestModel()));
-
-        $this->assertSame('bar', $this->valuestore->get('foo'));
+        $this->assertFalse($passes);
     }
 }
 
@@ -319,16 +310,5 @@ class ExceptionJob
     public function failed(\Throwable $e)
     {
         $this->valuestore->put('exeception', $e->getMessage());
-    }
-}
-
-class FooJobWithMethod
-{
-    // variadic arguments must be used so the container doesn't try to inject any value
-    public function foo(...$arguments)
-    {
-        [$valuestore] = $arguments;
-
-        $valuestore->put('foo', 'bar');
     }
 }


### PR DESCRIPTION
When you pass a closure instead of a class there is obviously no `failed` method which can be called in case of a failure. This PR adds a simple check and let's the exception bubble up.

I raised the PR to 1.x (because that's what I use with Tenancy package) but can of course adapt the changes to 2.x as well if you want.