### PR TITLE
fix: handle errors in closures

### DIFF
--- a/src/JobPipeline.php
+++ b/src/JobPipeline.php
@@ -72,7 +72,7 @@ class JobPipeline implements ShouldQueue
             try {
                 $result = app()->call($job);
             } catch (Throwable $exception) {
-                if (method_exists(get_class($job[0]), 'failed')) {
+                if (is_array($job) && method_exists(get_class($job[0]), 'failed')) {
                     call_user_func_array([$job[0], 'failed'], [$exception]);
                 } else {
                     throw $exception;

--- a/tests/JobPipelineTest.php
+++ b/tests/JobPipelineTest.php
@@ -2,6 +2,7 @@
 
 namespace Stancl\JobPipeline\Tests;
 
+use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
@@ -192,6 +193,22 @@ class JobPipelineTest extends TestCase
         event(new TestEvent(new TestModel()));
 
         $this->assertTrue($passes);
+    }
+
+    /** @test */
+    public function failures_in_closures_will_throw_correctly()
+    {
+        $this->expectExceptionMessage('foobar');
+
+        Event::listen(TestEvent::class, JobPipeline::make([
+            function () {
+                throw new Exception('foobar');
+            }
+        ])->send(function (TestEvent $event) {
+            return $this->valuestore;
+        })->shouldBeQueued(false)->toListener());
+
+        event(new TestEvent(new TestModel()));
     }
 }
 


### PR DESCRIPTION
Same as https://github.com/archtechx/jobpipeline/pull/16 but for 2.x