### PR TITLE
Fix PHP 8.4 deprecation warning

### DIFF
--- a/src/JobPipeline.php
+++ b/src/JobPipeline.php
@@ -28,7 +28,7 @@ class JobPipeline implements ShouldQueue
 
     public string $queue;
 
-    public function __construct($jobs, callable $send = null, bool $shouldBeQueued = null)
+    public function __construct($jobs, ?callable $send = null, ?bool $shouldBeQueued = null)
     {
         $this->jobs = $jobs;
         $this->send = $send ?? function ($event) {


### PR DESCRIPTION
 WARN  PHP Deprecated: Stancl\JobPipeline\JobPipeline::__construct(): Implicitly marking parameter $send as nullable is deprecated, the explicit nullable type must be used instead in vendor/stancl/jobpipeline/src/JobPipeline.php on line 31.