### PR TITLE
Update JobPipeline.php

### DIFF
--- a/src/JobPipeline.php
+++ b/src/JobPipeline.php
@@ -51,7 +51,7 @@ class JobPipeline implements ShouldQueue
         return $this;
     }
 
-    public function shouldBeQueued(bool $shouldBeQueued = true, string $queue = null)
+    public function shouldBeQueued(bool $shouldBeQueued = true, ?string $queue = null)
     {
         $this->shouldBeQueued = $shouldBeQueued;
 


### PR DESCRIPTION
$queue string labelled as explicitly nullable for php 8.2+ to prevent deprecation warnings.