### PR TITLE
Add missing return type (1.x)

### DIFF
--- a/src/JobPipeline.php
+++ b/src/JobPipeline.php
@@ -50,7 +50,7 @@ class JobPipeline implements ShouldQueue
         return $this;
     }
 
-    public function shouldBeQueued(bool $shouldBeQueued = true)
+    public function shouldBeQueued(bool $shouldBeQueued = true): self
     {
         $this->shouldBeQueued = $shouldBeQueued;
 


### PR DESCRIPTION
This adds the `self` return type to `JobPipeline::shouldBeQueued()` so that static analyzers won't get confused and treat its return value as `mixed`.

thought: since `JobPipeline` is not final, the `static` might be a better fit than `self`. However, the latter is already in use elsewhere, so I went with that. I can amend the PR to use `static` if desired :)

PR for 2.x: #24 